### PR TITLE
test: increase example coverage with mocked HTTP module

### DIFF
--- a/tests/example/advanced-configuration-example.test.ts
+++ b/tests/example/advanced-configuration-example.test.ts
@@ -3,6 +3,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@fjell/http-api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}), { virtual: true });
+
+import { get, post } from '@fjell/http-api';
+
 import {
   advancedConfigurationExample,
   contentTypeExample,
@@ -17,107 +25,57 @@ describe('Advanced Configuration Example', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => { });
     vi.spyOn(console, 'error').mockImplementation(() => { });
+    get.mockReset();
+    post.mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('customHeadersExample should execute without throwing', async () => {
-    try {
-      await customHeadersExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('customHeadersExample executes HTTP requests', async () => {
+    get.mockResolvedValue({});
+    await customHeadersExample();
+    expect(get).toHaveBeenCalled();
   });
 
-  test('contentTypeExample should execute without throwing', async () => {
-    try {
-      await contentTypeExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('contentTypeExample executes HTTP requests', async () => {
+    post.mockResolvedValue({});
+    await contentTypeExample();
+    expect(post).toHaveBeenCalled();
   });
 
-  test('requestCredentialsExample should execute without throwing', async () => {
-    try {
-      await requestCredentialsExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('requestCredentialsExample executes HTTP requests', async () => {
+    get.mockResolvedValue({});
+    post.mockResolvedValue({});
+    await requestCredentialsExample();
+    expect(get).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
   });
 
-  test('queryParametersExample should execute without throwing', async () => {
-    try {
-      await queryParametersExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('queryParametersExample executes HTTP requests', async () => {
+    get.mockResolvedValue({});
+    await queryParametersExample();
+    expect(get).toHaveBeenCalled();
   });
 
-  test('responseHandlingExample should execute without throwing', async () => {
-    try {
-      await responseHandlingExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('responseHandlingExample executes HTTP requests', async () => {
+    get.mockResolvedValue({});
+    await responseHandlingExample();
+    expect(get).toHaveBeenCalled();
   });
 
-  test('advancedConfigurationExample should execute without throwing', async () => {
-    try {
-      await advancedConfigurationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('advancedConfigurationExample executes all examples', async () => {
+    get.mockResolvedValue({});
+    post.mockResolvedValue({});
+    await advancedConfigurationExample();
+    expect(get).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
   });
 
-  test('environmentConfigExample should execute without throwing', async () => {
-    try {
-      await environmentConfigExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('environmentConfigExample executes HTTP requests', async () => {
+    get.mockResolvedValue({});
+    await environmentConfigExample();
+    expect(get).toHaveBeenCalled();
   });
 });

--- a/tests/example/authentication-example.test.ts
+++ b/tests/example/authentication-example.test.ts
@@ -3,6 +3,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@fjell/http-api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+}), { virtual: true });
+
+import { get, post, put } from '@fjell/http-api';
+
 import {
   apiKeyAuthenticationExample,
   bearerTokenAuthenticationExample,
@@ -16,79 +25,52 @@ describe('Authentication Example', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => { });
     vi.spyOn(console, 'error').mockImplementation(() => { });
+    get.mockReset();
+    post.mockReset();
+    put.mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('apiKeyAuthenticationExample should execute without throwing', async () => {
-    try {
-      await apiKeyAuthenticationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('apiKeyAuthenticationExample makes authenticated requests', async () => {
+    get.mockResolvedValue({});
+    await apiKeyAuthenticationExample();
+    expect(get).toHaveBeenCalledTimes(2);
   });
 
-  test('bearerTokenAuthenticationExample should execute without throwing', async () => {
-    try {
-      await bearerTokenAuthenticationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('bearerTokenAuthenticationExample makes authenticated requests', async () => {
+    get.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+    post.mockResolvedValueOnce({});
+    put.mockResolvedValueOnce({});
+    await bearerTokenAuthenticationExample();
+    expect(get).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
+    expect(put).toHaveBeenCalled();
   });
 
-  test('customAuthenticationExample should execute without throwing', async () => {
-    try {
-      await customAuthenticationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('customAuthenticationExample supports multiple auth methods', async () => {
+    get.mockResolvedValue({});
+    post.mockResolvedValue({});
+    await customAuthenticationExample();
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(post).toHaveBeenCalledTimes(1);
   });
 
-  test('sessionBasedAuthenticationExample should execute without throwing', async () => {
-    try {
-      await sessionBasedAuthenticationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('sessionBasedAuthenticationExample performs login and logout', async () => {
+    post.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+    get.mockResolvedValueOnce({});
+    await sessionBasedAuthenticationExample();
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(get).toHaveBeenCalledTimes(1);
   });
 
-  test('refreshTokenExample should execute without throwing', async () => {
-    try {
-      await refreshTokenExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('refreshTokenExample refreshes and uses new token', async () => {
+    post.mockResolvedValueOnce({ access_token: 'new-token' });
+    get.mockResolvedValueOnce({});
+    await refreshTokenExample();
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/example/basic-http-methods.test.ts
+++ b/tests/example/basic-http-methods.test.ts
@@ -2,53 +2,53 @@
  * Integration test for basic HTTP methods example
  */
 
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@fjell/http-api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  deleteMethod: vi.fn(),
+}), { virtual: true });
+
+import { deleteMethod, get, post, put } from '@fjell/http-api';
 import { basicHttpExamples, errorHandlingExample } from '../../examples/basic-http-methods';
 
 describe('Basic HTTP Methods Example', () => {
-  test('basicHttpExamples should execute without throwing', async () => {
-    // Mock console.log to avoid cluttering test output
-    const originalLog = console.log;
-    console.log = vi.fn();
-
-    try {
-      await basicHttpExamples();
-      // If we get here, the function completed successfully
-      expect(true).toBe(true);
-    } catch (error) {
-      // The example may fail due to network issues, but we want to ensure
-      // the code structure is sound. Only fail for syntax/import errors
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      // Network/API errors are expected in test environment
-      expect(error).toBeInstanceOf(Error);
-    } finally {
-      console.log = originalLog;
-    }
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => { });
+    vi.spyOn(console, 'error').mockImplementation(() => { });
+    get.mockReset();
+    post.mockReset();
+    put.mockReset();
+    deleteMethod.mockReset();
   });
 
-  test('errorHandlingExample should execute without throwing', async () => {
-    const originalLog = console.log;
-    const originalError = console.error;
-    console.log = vi.fn();
-    console.error = vi.fn();
+  test('basicHttpExamples makes expected HTTP calls', async () => {
+    get
+      .mockResolvedValueOnce([{ id: 1, name: 'User' }])
+      .mockResolvedValueOnce([{ id: 1, username: 'Bret' }]);
+    post
+      .mockResolvedValueOnce({ id: 101 })
+      .mockResolvedValueOnce({ id: 201 });
+    put.mockResolvedValueOnce({ id: 1 });
+    deleteMethod.mockResolvedValueOnce();
 
-    try {
-      await errorHandlingExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    } finally {
-      console.log = originalLog;
-      console.error = originalError;
-    }
+    await basicHttpExamples();
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(deleteMethod).toHaveBeenCalledTimes(1);
+  });
+
+  test('errorHandlingExample handles request errors', async () => {
+    get.mockRejectedValueOnce(new Error('Not found'));
+    post.mockRejectedValueOnce(new Error('Validation error'));
+
+    await errorHandlingExample();
+
+    expect(get).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
   });
 });

--- a/tests/example/error-handling-example.test.ts
+++ b/tests/example/error-handling-example.test.ts
@@ -3,6 +3,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@fjell/http-api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  deleteMethod: vi.fn(),
+}), { virtual: true });
+
+import { deleteMethod, get, post } from '@fjell/http-api';
+
 import {
   basicErrorHandlingExample,
   errorLoggingExample,
@@ -15,79 +24,75 @@ describe('Error Handling Example', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => { });
     vi.spyOn(console, 'error').mockImplementation(() => { });
+    get.mockReset();
+    post.mockReset();
+    deleteMethod.mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('basicErrorHandlingExample should execute without throwing', async () => {
-    try {
-      await basicErrorHandlingExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('basicErrorHandlingExample processes different error statuses', async () => {
+    get
+      .mockRejectedValueOnce({ message: 'Not found', status: 404 })
+      .mockRejectedValueOnce({ message: 'Unauthorized', status: 401 })
+      .mockRejectedValueOnce({ message: 'Server error', status: 500 });
+    deleteMethod.mockRejectedValueOnce({ message: 'Forbidden', status: 403 });
+    post.mockRejectedValueOnce({ message: 'Bad request', status: 400 });
+
+    await basicErrorHandlingExample();
+
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(deleteMethod).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(1);
   });
 
-  test('retryLogicExample should execute without throwing', async () => {
-    try {
-      await retryLogicExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
-  }, 10000); // 10 second timeout for retry logic
+  test('retryLogicExample retries failed requests', async () => {
+    vi.useFakeTimers();
+    get
+      .mockRejectedValueOnce({ status: 500, message: 'fail 1' })
+      .mockRejectedValueOnce({ status: 500, message: 'fail 2' })
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce({ status: 429, headers: { 'retry-after': '1' }, message: 'rate limit' })
+      .mockResolvedValueOnce({ ok: true });
 
-  test('timeoutHandlingExample should execute without throwing', async () => {
-    try {
-      await timeoutHandlingExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+    const promise = retryLogicExample();
+    await vi.runAllTimersAsync();
+    await promise;
+    vi.useRealTimers();
+
+    expect(get).toHaveBeenCalled();
+  }, 10000);
+
+  test('timeoutHandlingExample handles slow requests', async () => {
+    vi.useFakeTimers();
+    get.mockResolvedValue({});
+    const promise = timeoutHandlingExample();
+    await vi.runAllTimersAsync();
+    await promise;
+    vi.useRealTimers();
+
+    expect(get).toHaveBeenCalled();
   });
 
-  test('errorRecoveryExample should execute without throwing', async () => {
-    try {
-      await errorRecoveryExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('errorRecoveryExample falls back when needed', async () => {
+    get
+      .mockRejectedValueOnce(new Error('primary failed'))
+      .mockResolvedValueOnce({})
+      .mockResolvedValue({});
+
+    await errorRecoveryExample();
+    expect(get).toHaveBeenCalled();
   });
 
-  test('errorLoggingExample should execute without throwing', async () => {
-    try {
-      await errorLoggingExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('errorLoggingExample logs errors from requests', async () => {
+    get.mockRejectedValueOnce(new Error('get failed'));
+    post.mockRejectedValueOnce(new Error('post failed'));
+
+    await errorLoggingExample();
+
+    expect(get).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
   });
 });

--- a/tests/example/file-upload-example.test.ts
+++ b/tests/example/file-upload-example.test.ts
@@ -3,6 +3,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@fjell/http-api', () => ({
+  post: vi.fn(),
+  postFileMethod: vi.fn(),
+  uploadAsyncMethod: vi.fn(),
+}), { virtual: true });
+
+import { post, postFileMethod, uploadAsyncMethod } from '@fjell/http-api';
+
 import {
   asyncFileUploadExample,
   basicFileUploadExample,
@@ -15,79 +24,56 @@ describe('File Upload Example', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => { });
     vi.spyOn(console, 'error').mockImplementation(() => { });
+    post.mockReset();
+    postFileMethod.mockReset();
+    uploadAsyncMethod.mockReset();
+    (fetch as any).mockReset && (fetch as any).mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test('basicFileUploadExample should execute without throwing', async () => {
-    try {
-      await basicFileUploadExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('basicFileUploadExample uploads a file', async () => {
+    postFileMethod.mockResolvedValue({ id: '1' });
+    await basicFileUploadExample();
+    expect(postFileMethod).toHaveBeenCalled();
   });
 
-  test('asyncFileUploadExample should execute without throwing', async () => {
-    try {
-      await asyncFileUploadExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('asyncFileUploadExample handles async uploads', async () => {
+    vi.useFakeTimers();
+    uploadAsyncMethod.mockResolvedValue({ upload_id: '123', status: 'processing' });
+    (fetch as any).mockResponseOnce(JSON.stringify({ status: 'completed', progress: 100 }));
+
+    const promise = asyncFileUploadExample();
+    await vi.runAllTimersAsync();
+    await promise;
+    vi.useRealTimers();
+
+    expect(uploadAsyncMethod).toHaveBeenCalled();
+    expect((fetch as any).mock.calls.length).toBeGreaterThan(0);
   });
 
-  test('multipleFileUploadExample should execute without throwing', async () => {
-    try {
-      await multipleFileUploadExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('multipleFileUploadExample uploads multiple files', async () => {
+    postFileMethod.mockResolvedValue({});
+    post.mockResolvedValue({});
+    await multipleFileUploadExample();
+    expect(postFileMethod).toHaveBeenCalled();
+    expect(post).toHaveBeenCalled();
   });
 
-  test('resumableUploadExample should execute without throwing', async () => {
-    try {
-      await resumableUploadExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('resumableUploadExample performs chunked upload', async () => {
+    post.mockResolvedValueOnce({ upload_url: 'http://upload', session_id: 'abc' });
+    postFileMethod.mockResolvedValue({});
+    post.mockResolvedValue({});
+    await resumableUploadExample();
+    expect(post).toHaveBeenCalled();
+    expect(postFileMethod).toHaveBeenCalled();
   });
 
-  test('fileUploadWithValidationExample should execute without throwing', async () => {
-    try {
-      await fileUploadWithValidationExample();
-      expect(true).toBe(true);
-    } catch (error) {
-      if (error.message?.includes('Cannot resolve module') ||
-        error.message?.includes('SyntaxError') ||
-        error.message?.includes('TypeError')) {
-        throw error;
-      }
-      expect(error).toBeInstanceOf(Error);
-    }
+  test('fileUploadWithValidationExample validates before upload', async () => {
+    postFileMethod.mockResolvedValue({});
+    await fileUploadWithValidationExample();
+    expect(postFileMethod).toHaveBeenCalled();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@fjell/http-api': resolve(__dirname, 'src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     include: ['tests/**/*.test.ts'],
@@ -9,7 +18,7 @@ export default defineConfig({
       reporter: ['text', 'lcov', 'html'],
       reportsDirectory: 'coverage',
       all: true,
-      include: ['src/**/*.ts'],
+      include: ['src/**/*.ts', 'examples/**/*.ts'],
       thresholds: {
         global: {
           branches: 66,


### PR DESCRIPTION
## Summary
- mock `@fjell/http-api` in example tests and assert expected HTTP interactions
- measure example files in coverage and alias package for test runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b0dff74883258cfcce282c7a1bf7