### PR TITLE
test: cover example error paths

### DIFF
--- a/tests/example/advanced-configuration-example.test.ts
+++ b/tests/example/advanced-configuration-example.test.ts
@@ -39,6 +39,14 @@ describe('Advanced Configuration Example', () => {
     expect(get).toHaveBeenCalled();
   });
 
+  test('customHeadersExample handles request errors', async () => {
+    get.mockRejectedValueOnce(new Error('failure'));
+
+    await customHeadersExample();
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
   test('contentTypeExample executes HTTP requests', async () => {
     post.mockResolvedValue({});
     await contentTypeExample();

--- a/tests/example/authentication-example.test.ts
+++ b/tests/example/authentication-example.test.ts
@@ -40,6 +40,14 @@ describe('Authentication Example', () => {
     expect(get).toHaveBeenCalledTimes(2);
   });
 
+  test('apiKeyAuthenticationExample handles errors', async () => {
+    get.mockRejectedValueOnce(new Error('unauthorized'));
+
+    await apiKeyAuthenticationExample();
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
   test('bearerTokenAuthenticationExample makes authenticated requests', async () => {
     get.mockResolvedValueOnce({}).mockResolvedValueOnce({});
     post.mockResolvedValueOnce({});

--- a/tests/example/basic-http-methods.test.ts
+++ b/tests/example/basic-http-methods.test.ts
@@ -51,4 +51,12 @@ describe('Basic HTTP Methods Example', () => {
     expect(get).toHaveBeenCalled();
     expect(post).toHaveBeenCalled();
   });
+
+  test('basicHttpExamples logs errors on failure', async () => {
+    get.mockRejectedValueOnce(new Error('Network error'));
+
+    await basicHttpExamples();
+
+    expect(console.error).toHaveBeenCalled();
+  });
 });

--- a/tests/example/file-upload-example.test.ts
+++ b/tests/example/file-upload-example.test.ts
@@ -40,6 +40,14 @@ describe('File Upload Example', () => {
     expect(postFileMethod).toHaveBeenCalled();
   });
 
+  test('basicFileUploadExample handles upload errors', async () => {
+    postFileMethod.mockRejectedValueOnce(new Error('upload failed'));
+
+    await basicFileUploadExample();
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
   test('asyncFileUploadExample handles async uploads', async () => {
     vi.useFakeTimers();
     uploadAsyncMethod.mockResolvedValue({ upload_id: '123', status: 'processing' });


### PR DESCRIPTION
## Summary
- add tests that hit error branches in example modules
- ensure example files handle failed HTTP requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b5ce85608325b607f610dddbeacc